### PR TITLE
feat: exposing formattingFn component prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Method called before animation starts
 ##### `easingFn`: function
 Method to customize easing the function. See also [here](https://github.com/inorganik/countUp.js#custom-easing)
 
+##### `formattingFn`: function
+Method to customize the formatting of the number
+
 ## Advanced Usage
 By default, the animation triggered if any of the follow props has changed:
 - `duration`

--- a/index.jsx
+++ b/index.jsx
@@ -10,6 +10,7 @@ type Props = {
   duration?: number,
   easingFn?: () => void,
   end: number,
+  formattingFn?: () => void,
   onComplete?: () => void,
   onStart?: () => void,
   prefix?: string,
@@ -30,6 +31,7 @@ export const startAnimation = (component: Component<*, *, *>) => {
       duration,
       easingFn,
       end,
+      formattingFn,
       onComplete,
       onStart,
       prefix,
@@ -49,6 +51,7 @@ export const startAnimation = (component: Component<*, *, *>) => {
       {
         decimal,
         easingFn,
+        formattingFn,
         separator,
         prefix,
         suffix,
@@ -78,8 +81,9 @@ export default class CountUp extends Component {
     decimal: '.',
     decimals: 0,
     duration: 3,
-    easingFn: undefined,
+    easingFn: null,
     end: 100,
+    formattingFn: null,
     onComplete: undefined,
     onStart: undefined,
     prefix: '',
@@ -97,7 +101,8 @@ export default class CountUp extends Component {
   }
 
   shouldComponentUpdate(nextProps: Props) {
-    const hasCertainPropsChanged = this.props.duration !== nextProps.duration ||
+    const hasCertainPropsChanged =
+      this.props.duration !== nextProps.duration ||
       this.props.end !== nextProps.end ||
       this.props.start !== nextProps.start;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-countup",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "A React component wrapper around CountUp.js",
   "author": "Glenn Reyes",
   "keywords": [
@@ -38,7 +38,7 @@
     "react": ">=0.15.0"
   },
   "dependencies": {
-    "countup.js": "^1.8.3",
+    "countup.js": "^1.8.5",
     "react": "15.4.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,17 +898,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.16.0, babel-template@^6.22.0, babel-template@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.23.0.tgz#04d4f270adbb3aa704a8143ae26faa529238e638"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.24.1:
+babel-template@^6.16.0, babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -918,21 +908,17 @@ babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.23.1:
-  version "6.23.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
+babel-template@^6.22.0, babel-template@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.23.0.tgz#04d4f270adbb3aa704a8143ae26faa529238e638"
   dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.23.0"
     babel-runtime "^6.22.0"
+    babel-traverse "^6.23.0"
     babel-types "^6.23.0"
-    babylon "^6.15.0"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
+    babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.24.1:
+babel-traverse@^6.18.0, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -946,18 +932,32 @@ babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
+babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.23.1:
+  version "6.23.1"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.23.0"
+    babylon "^6.15.0"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
     babel-runtime "^6.22.0"
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
+babel-types@^6.22.0, babel-types@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
   dependencies:
     babel-runtime "^6.22.0"
     esutils "^2.0.2"
@@ -1236,9 +1236,9 @@ cosmiconfig@^1.1.0:
     pinkie-promise "^2.0.0"
     require-from-string "^1.1.0"
 
-countup.js@^1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/countup.js/-/countup.js-1.8.3.tgz#d4fa30f468c056f004daeca17dfa6596ac1d32cf"
+countup.js@^1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/countup.js/-/countup.js-1.8.5.tgz#0941f62c605835c601478b45e8c096b16d7e9881"
 
 cross-spawn@^5.0.1:
   version "5.1.0"


### PR DESCRIPTION
I have exposed the `formattingFn` countup.js [option](https://github.com/inorganik/countUp.js/blob/master/countUp.js#L76) as a property on the React component.

Please note that I have also set `easingFn` to `null` rather than `undefined`. Since release countup 1.8.4 when custom options get merged with default options it looks for non-null values rather than defined.