### PR TITLE
docs: Updating advanced example to render separator and decimals

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ render(
   <CountUp
     className="custom-count"
     start={160527.0127}
-    end={-875}
+    end={-875.0319}
     duration={2.75}
     useEasing={true}
+    useGrouping={true}
     separator=" "
+    decimals={4}
     decimal=","
     prefix="EUR "
     suffix=" left"


### PR DESCRIPTION
Was playing with the advanced example and noticed that the numbers were not delimited or showing decimals as expected. Looking at the source, useGrouping defaults to false and decimals defaults to 0, which would explain why those weren't rendering.