### PR TITLE
Exlude-Src-From-Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "homepage": "https://react-countup.now.sh",
   "main": "build",
   "files": [
-    "build",
-    "src"
+    "build"
   ],
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
I got some problems with last version:
I use **react-countup** with [react-starter-kit](https://github.com/kriasoft/react-starter-kit)
You can check [reproduction](https://github.com/mmarkelov/react-starter-kit/tree/CountUp)
When I run ```yarn run start```
I got 
```
ERROR in ./node_modules/react-countup/src/countup.js 7:19
Module parse failed: Unexpected token (7:19)
You may need an appropriate loader to handle this file type.
| 
| class CountUp extends Component {
>   static propTypes = {
|     decimal: PropTypes.string,
|     decimals: PropTypes.number,
 @ ./node_modules/react-countup/build/index.js 5:28-49
 @ ./src/routes/home/Home.js
 @ ./src/routes/home/index.js
 @ ./src/routes/index.js
 @ ./src/router.js
 @ ./src/client.js
 @ multi @babel/polyfill/noConflict ./tools/lib/webpackHotDevClient ./src/client.js
```
But it seems okay when I use just built file without **src** 
Actually, I suppose src is unnecessary in built package