### PR TITLE
Fix error thrown when using with SVG text

### DIFF
--- a/src/CountUp.js
+++ b/src/CountUp.js
@@ -95,7 +95,8 @@ class CountUp extends Component {
       // Warn when user didn't use containerRef at all
       warning(
         this.containerRef.current &&
-          this.containerRef.current instanceof HTMLElement,
+          (this.containerRef.current instanceof HTMLElement ||
+          this.containerRef.current instanceof SVGTextElement),
         `Couldn't find attached element to hook the CountUp instance into! Try to attach "containerRef" from the render prop to a an HTMLElement, eg. <span ref={containerRef} />.`,
       );
     }


### PR DESCRIPTION
The library will throw a warning when you use the containerRef with a SVG text element because the check only checks for HTMLElements.

Example:
```ts
      <CountUp start={0} end={data.data} delay={0} duration={1}>
        {({ countUpRef }) =>
          <text
            dy="-0.5em"
            x="0"
            y="15"
            textAnchor="middle"
            ref={countUpRef}
          />
        }
      </CountUp>
```