### PR TITLE
Recreate instance on suffix, prefix and separator change

### DIFF
--- a/src/CountUp.js
+++ b/src/CountUp.js
@@ -71,7 +71,10 @@ class CountUp extends Component {
     // restart it.
     if (
       this.props.duration !== prevProps.duration ||
-      this.props.start !== prevProps.start
+      this.props.start !== prevProps.start ||
+      this.props.suffix !== prevProps.suffix ||
+      this.props.prefix !== prevProps.prefix ||
+      this.props.separator !== prevProps.separator
     ) {
       this.instance.reset();
       this.instance = this.createInstance();

--- a/src/CountUp.js
+++ b/src/CountUp.js
@@ -57,24 +57,40 @@ class CountUp extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    const hasCertainPropsChanged =
-      this.props.duration !== nextProps.duration ||
-      this.props.end !== nextProps.end ||
-      this.props.start !== nextProps.start;
+    const { end, start, suffix, prefix, redraw, duration } = this.props;
 
-    return hasCertainPropsChanged || this.props.redraw;
+    const hasCertainPropsChanged =
+      duration !== nextProps.duration ||
+      end !== nextProps.end ||
+      start !== nextProps.start ||
+      suffix !== nextProps.suffix ||
+      prefix !== nextProps.prefix ||
+      separator !== nextProps.separator;
+
+    return hasCertainPropsChanged || redraw;
   }
 
   componentDidUpdate(prevProps) {
-    // If duration or start has changed, there's no way to update the duration
-    // or start value. So we need to re-create the CountUp instance in order to
+    // If duration, suffix, prefix, separator or start has changed
+    // there's no way to update the values.
+    // So we need to re-create the CountUp instance in order to
     // restart it.
+    const {
+      end,
+      start,
+      suffix,
+      prefix,
+      duration,
+      separator,
+      preserveValue,
+    } = this.props;
+
     if (
-      this.props.duration !== prevProps.duration ||
-      this.props.start !== prevProps.start ||
-      this.props.suffix !== prevProps.suffix ||
-      this.props.prefix !== prevProps.prefix ||
-      this.props.separator !== prevProps.separator
+      duration !== prevProps.duration ||
+      start !== prevProps.start ||
+      suffix !== prevProps.suffix ||
+      prefix !== prevProps.suffix ||
+      separator !== prevProps.separator
     ) {
       this.instance.reset();
       this.instance = this.createInstance();
@@ -83,11 +99,11 @@ class CountUp extends Component {
 
     // Only end value has changed, so reset and and re-animate with the updated
     // end value.
-    if (this.props.end !== prevProps.end) {
-      if (!this.props.preserveValue) {
+    if (end !== prevProps.end) {
+      if (!preserveValue) {
         this.instance.reset();
       }
-      this.instance.update(this.props.end);
+      this.instance.update(end);
     }
   }
 

--- a/src/CountUp.js
+++ b/src/CountUp.js
@@ -57,7 +57,15 @@ class CountUp extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    const { end, start, suffix, prefix, redraw, duration } = this.props;
+    const {
+      end,
+      start,
+      suffix,
+      prefix,
+      redraw,
+      duration,
+      separator,
+    } = this.props;
 
     const hasCertainPropsChanged =
       duration !== nextProps.duration ||

--- a/src/__tests__/CountUp.test.js
+++ b/src/__tests__/CountUp.test.js
@@ -51,7 +51,7 @@ it('re-renders when suffix changes', done => {
     const span = container.firstChild;
     expect(span.textContent).toEqual('30 seconds');
     done();
-  }, 1000);
+  }, 1200);
 });
 
 it('re-renders when the separator changes', done => {
@@ -59,13 +59,13 @@ it('re-renders when the separator changes', done => {
     <CountUp duration={1} end={1} separator="" />,
   );
 
-  rerender(<CountUp duration={1} end={30} separator=" " />);
+  rerender(<CountUp duration={1} end={3000} separator=" " />);
 
   setTimeout(() => {
     const span = container.firstChild;
-    expect(span.textContent).toEqual('30');
+    expect(span.textContent).toEqual('3 000');
     done();
-  }, 1000);
+  }, 1200);
 });
 
 it('re-renders when the prefix changes', done => {
@@ -79,7 +79,7 @@ it('re-renders when the prefix changes', done => {
     const span = container.firstChild;
     expect(span.textContent).toEqual('->30');
     done();
-  }, 1000);
+  }, 1200);
 });
 
 it('re-renders change of end value correctly', () => {

--- a/src/__tests__/CountUp.test.js
+++ b/src/__tests__/CountUp.test.js
@@ -40,6 +40,48 @@ it('clear previous counter when duration changed', done => {
   }, 1200);
 });
 
+it('re-renders when suffix changes', done => {
+  const { container, rerender } = render(
+    <CountUp duration={1} end={1} suffix="second" />,
+  );
+
+  rerender(<CountUp duration={1} end={30} suffix=" seconds" />);
+
+  setTimeout(() => {
+    const span = container.firstChild;
+    expect(span.textContent).toEqual('30 seconds');
+    done();
+  }, 1000);
+});
+
+it('re-renders when the separator changes', done => {
+  const { container, rerender } = render(
+    <CountUp duration={1} end={1} separator="" />,
+  );
+
+  rerender(<CountUp duration={1} end={30} separator=" " />);
+
+  setTimeout(() => {
+    const span = container.firstChild;
+    expect(span.textContent).toEqual('30');
+    done();
+  }, 1000);
+});
+
+it('re-renders when the prefix changes', done => {
+  const { container, rerender } = render(
+    <CountUp duration={1} end={1} prefix="" />,
+  );
+
+  rerender(<CountUp duration={1} end={30} prefix="->" />);
+
+  setTimeout(() => {
+    const span = container.firstChild;
+    expect(span.textContent).toEqual('->30');
+    done();
+  }, 1000);
+});
+
 it('re-renders change of end value correctly', () => {
   const { container, rerender } = render(<CountUp end={10} />);
 


### PR DESCRIPTION
Related Issue #151 

Recreate the countup instance when `suffix`, `prefix` and `separator` props change