### PR TITLE
Check for `tspan` elements when creating CountUp instances

### DIFF
--- a/src/CountUp.js
+++ b/src/CountUp.js
@@ -128,7 +128,8 @@ class CountUp extends Component {
       warning(
         this.containerRef.current &&
           (this.containerRef.current instanceof HTMLElement ||
-            this.containerRef.current instanceof SVGTextElement),
+            this.containerRef.current instanceof SVGTextElement ||
+            this.containerRef.current instanceof SVGTSpanElement),
         `Couldn't find attached element to hook the CountUp instance into! Try to attach "containerRef" from the render prop to a an HTMLElement, eg. <span ref={containerRef} />.`,
       );
     }


### PR DESCRIPTION
Noticed the error `Warning: Couldn't find attached element to hook the CountUp instance into! Try to attach "containerRef" from the render prop to a an HTMLElement, eg. <span ref={containerRef} />.` crop up when working on building out components.

The check only looks for HTML or the `text` SVG Elements... this extends it to also include `tspan`.

`tspan` elements are for text within SVG `text` elements to individually apply styling or positioning. Hence, they should be considered as well when checking for elements to attach the `containerRef` to.

Example:

```tsx
<CountUp start={0} end={value} preserveValue={true} delay={0} decimals={1} duration={1}>
  {({ countUpRef }) => (
    <text
      className={styles.label}
      x={centerX}
      y={labelYOffset}
      textAnchor='middle'
      alignmentBaseline='central'
      fontSize='3rem'
      fill={trafficLightColor(value, total)}
    >
      <tspan ref={countUpRef} />
      <tspan>%</tspan>
    </text>
  )}
</CountUp>
```

Cheers
Patrik