### PR TITLE
Fix TS7051 error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,8 @@ export interface RenderCounterProps {
   update?: (newEnd?: number) => void;
 }
 
+type EasingFn = (t: number, b: number, c: number, d: number) => number;
+
 export interface CountUpProps extends CallbackProps {
   className?: string;
   decimal?: string;
@@ -54,7 +56,7 @@ export interface CountUpProps extends CallbackProps {
   start?: number;
   suffix?: string;
   useEasing?: boolean;
-  easingFn?: (t: number, b: number, c: number, d: number) => number;
+  easingFn?: EasingFn;
   formattingFn?: (n: number) => string;
   children?: (props: RenderCounterProps) => JSX.Element;
 }
@@ -67,10 +69,12 @@ export interface useCountUpProps extends CallbackProps {
   end: number;
   delay?: number;
   duration?: number;
+  easingFn?: EasingFn;
+  separator?: string;
 }
 
 type countUpHook = (
-  useCountUpProps,
+  arg: useCountUpProps,
 ) => {
   countUp: number | string;
   start: Function;


### PR DESCRIPTION
Fixes #253 

After using the `useCountUp` hook the typescript compiler prints the following error:
```
node_modules/react-countup/index.d.ts:73:3 - error TS7051: Parameter has a name but no type. Did you mean 'arg0: useCountUpProps'?

73   useCountUpProps,
     ~~~~~~~~~~~~~~~
```

This PR fixes this issue.

Additionally added some missing fields in `useCountUpProps` definition