### PR TITLE
Clear timeout when component unmounts

### DIFF
--- a/src/useCountUp.js
+++ b/src/useCountUp.js
@@ -72,7 +72,10 @@ const useCountUp = props => {
         });
       }, delay * 1000);
     }
-    return reset;
+    return () => {
+      clearTimeout(timeout);
+      reset();
+    }
   }, []);
 
   return { countUp: count, start: restart, pauseResume, reset, update };


### PR DESCRIPTION
If you don't clear the timeout, there's a chance it will end up firing after everything cleans up, which looks like it restarts the process and will cause React to throw some warnings.