### PR TITLE
Update default duration to 2

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -6,7 +6,7 @@
     "prism-react-renderer": "^1.2.1",
     "prop-types": "^15.6.2",
     "react": "^17.0.2",
-    "react-countup": "^6.0.0-2",
+    "react-countup": "^6.1.0",
     "react-dom": "^17.0.2",
     "react-feather": "^2.0.9",
     "react-github-corner": "^2.5.0",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -10107,10 +10107,10 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
-react-countup@^6.0.0-2:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/react-countup/-/react-countup-6.0.0.tgz#463f174781db4bec25de8853335c18ff0a305131"
-  integrity sha512-Q5M8TbtdeSrnK6UaMgZBaV13GZHKsWh5FedzFM9HSWcI48x1SzJ33fCJcX23juLzguwRU3ZtumqlLdCUJdRPfA==
+react-countup@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-countup/-/react-countup-6.1.0.tgz#ac9b923ecf1351a0c3281209ba55952345814cd8"
+  integrity sha512-0tN65l4ksaNa4rm8ZKshpGxbIHQ4RAh8TGaKYp06EZ7nZw+haXpW3dQTVDhTey9+10jDkJgdzyXKDmC96c1M8g==
   dependencies:
     countup.js "^2.0.8"
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   testEnvironment: 'jsdom',
+  testTimeout: 10000,
   testURL: 'http://localhost',
 };

--- a/src/__tests__/CountUp.test.js
+++ b/src/__tests__/CountUp.test.js
@@ -5,18 +5,24 @@ import CountUp from '../index';
 afterEach(cleanup);
 
 describe('CountUp component', () => {
-  it('renders start value correctly', () => {
+  it('renders start value correctly', (done) => {
     const { container } = render(<CountUp end={10} />);
 
-    expect(container).toMatchSnapshot();
+    setTimeout(() => {
+      expect(container).toMatchSnapshot();
+      done();
+    }, 2000);
   });
 
-  it('re-renders change of start value correctly', () => {
+  it('re-renders change of start value correctly', (done) => {
     const { container, rerender } = render(<CountUp end={10} />);
 
     rerender(<CountUp start={5} end={10} />);
 
-    expect(container).toMatchSnapshot();
+    setTimeout(() => {
+      expect(container).toMatchSnapshot();
+      done();
+    }, 2000);
   });
 
   it('re-renders change of duration value correctly', () => {
@@ -113,12 +119,15 @@ describe('CountUp component', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('re-renders with redraw={false} correctly', () => {
+  it('re-renders with redraw={false} correctly', (done) => {
     const { container, rerender } = render(<CountUp redraw={false} end={10} />);
 
     rerender(<CountUp redraw={false} end={10} />);
 
-    expect(container).toMatchSnapshot();
+    setTimeout(() => {
+      expect(container).toMatchSnapshot();
+      done();
+    }, 2000);
   });
 
   it('renders with delay correctly', () => {

--- a/src/__tests__/useCountUp.test.js
+++ b/src/__tests__/useCountUp.test.js
@@ -7,7 +7,7 @@ import { useCountUp } from '../index';
 
 afterEach(cleanup);
 
-const checkContent = async (container, expectedValue, timeout = 1100) => {
+const checkContent = async (container, expectedValue, timeout = 2100) => {
   await act(() => {
     return new Promise((res) => {
       setTimeout(() => {

--- a/src/useCountUp.ts
+++ b/src/useCountUp.ts
@@ -15,6 +15,7 @@ const DEFAULTS = {
   delay: null,
   prefix: '',
   suffix: '',
+  duration: 2,
   start: 0,
   startOnMount: true,
   enableReinitialize: true,


### PR DESCRIPTION
There is mismatch with docs and current `duration`.
Decide to make it `2` just like in `CountUp` library.
Close #260 