### PR TITLE
Update startOnMount condition

### DIFF
--- a/src/CountUp.tsx
+++ b/src/CountUp.tsx
@@ -38,7 +38,7 @@ const CountUp: React.FC<CountUpProps> = (props) => {
   } = useCountUp({
     ...useCountUpProps,
     ref: containerRef,
-    startOnMount: typeof children !== 'function' || props.delay === 0,
+    startOnMount: typeof children !== 'function' || props.delay >== 0,
     // component manually restarts
     enableReinitialize: false,
   });


### PR DESCRIPTION
Currently if children are specified and delay is present it does not autostart the component.

This pull request fixes that behaviour allowing to autostart with delay and children present