### PR TITLE
[Fix] - add scrollSpyOnce to countup instance

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -20,6 +20,7 @@ export const createCountUpInstance = (
     useEasing,
     enableScrollSpy,
     scrollSpyDelay,
+    scrollSpyOnce
   } = props;
 
   return new CountUp(el, end, {
@@ -37,5 +38,6 @@ export const createCountUpInstance = (
     useGrouping: !!separator,
     enableScrollSpy,
     scrollSpyDelay,
+    scrollSpyOnce
   });
 };


### PR DESCRIPTION
The scrollSpyOnce prop was not being deconstructed and passed to the countup js instance