### PR TITLE
Move babel plugin to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react": ">= 16.3.0"
   },
   "dependencies": {
-    "@rollup/plugin-babel": "^6.0.3",
     "countup.js": "^2.5.0"
   },
   "devDependencies": {
@@ -42,6 +41,7 @@
     "@babel/preset-env": "7.20.2",
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "^7.14.5",
+    "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@testing-library/react": "13.4.0",
     "@typescript-eslint/eslint-plugin": "^5.44.0",


### PR DESCRIPTION
This PR moves the `@rollup/plugin-babel` to the `devDependencies`, because it's used only during the build process. This will help with 2 issues:
1. Installation size will be a bit smaller if nothing else has `@rollup/plugin-babel` specified in their dependencies.
2. This will get rid of the warning during an installation due to a peer dependency (`@babel/core`).

```bash
warning "react-countup > @rollup/plugin-babel@6.0.3" has unmet peer dependency "@babel/core@^7.0.0".
```