### PR TITLE
build: also output ESM bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "format": "prettier --write \"*.md\" \"src/**/*.ts\"  \"src/**/*.tsx\"",
     "build": "rm -rf build && rollup --bundleConfigAsCjs -c && tsc --emitDeclarationOnly --noEmit false --project src/tsconfig.json --outDir build",
-    "prepublishOnly": "yarn build",
+    "prepack": "yarn build",
     "test": "jest"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,15 +18,19 @@
     "url": "https://github.com/glennreyes/react-countup/issues"
   },
   "homepage": "https://react-countup.now.sh",
-  "main": "build",
+  "main": "build/index.js",
+  "exports": {
+    "import": "./build/index.mjs",
+    "require": "./build/index.js",
+    "types": "./build/index.d.ts"
+  },
   "files": [
-    "build/index.js",
-    "build/index.d.ts"
+    "build"
   ],
   "typings": "build/index.d.ts",
   "scripts": {
     "format": "prettier --write \"*.md\" \"src/**/*.ts\"  \"src/**/*.tsx\"",
-    "build": "rollup --bundleConfigAsCjs -c && tsc --emitDeclarationOnly --noEmit false --project src/tsconfig.json --outDir build",
+    "build": "rm -rf build && rollup --bundleConfigAsCjs -c && tsc --emitDeclarationOnly --noEmit false --project src/tsconfig.json --outDir build",
     "prepublishOnly": "yarn build",
     "test": "jest"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,10 +5,16 @@ const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 
 export default {
   input: 'src/index.ts',
-  output: {
-    file: 'build/index.js',
-    format: 'cjs',
-  },
+  output: [
+    {
+      file: 'build/index.js',
+      format: 'cjs',
+    },
+    {
+      file: 'build/index.mjs',
+      format: 'esm',
+    },
+  ],
   plugins: [
     resolve({ extensions }),
     babel({


### PR DESCRIPTION
Most FE application can better utilise ES modules libraries. Example: https://web.dev/articles/commonjs-larger-bundles